### PR TITLE
fix: Add return to Recipe.getRecipeIngredients method to fix modal po…

### DIFF
--- a/src/classes/Recipe.js
+++ b/src/classes/Recipe.js
@@ -33,7 +33,7 @@ class Recipe {
   }
 
   getRecipeIngredients(recipeInfo, ingredientsData) {
-    recipeInfo.ingredients.map(ingredient => {
+    return recipeInfo.ingredients.map(ingredient => {
       const findIngredient = ingredientsData.find(ingredientData => ingredientData.id === ingredient.id);
       return {
         ingredient: new Ingredient(findIngredient), 


### PR DESCRIPTION
…pulation

This fixes the bug where the recipe would be clicked but no information would populated in the modal. Turns out the `Recip.getRecipeIngredients` method was missing a `return`, so it wasn't giving any information.