### PR TITLE
Change build path from dist to public

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ module.exports = {
   "mode": "none",
   "entry": "./src/scripts.js",
   "output": {
-    "path": __dirname + '/dist',
+    "path": __dirname + '/public',
     "filename": "bundle.js",
     sourceMapFilename: "bundle.js.map"
   },


### PR DESCRIPTION
Changed build path to `public` for Vercel deployment.